### PR TITLE
Fixed xml syntax

### DIFF
--- a/src/main/java/org/mskcc/oncokb/curation/service/UserService.java
+++ b/src/main/java/org/mskcc/oncokb/curation/service/UserService.java
@@ -119,7 +119,12 @@ public class UserService {
                     .forEach(managedAuthorities::add);
                 Set<FeatureFlag> managedFeatureFlags = user.getFeatureFlags();
                 managedFeatureFlags.clear();
-                managedFeatureFlags.addAll(userDTO.getFeatureFlags());
+
+                Set<FeatureFlag> featureFlags = userDTO.getFeatureFlags();
+                if (featureFlags != null) {
+                    managedFeatureFlags.addAll(featureFlags);
+                }
+
                 this.clearUserCaches(user);
                 log.debug("Changed Information for User: {}", user);
                 return user;

--- a/src/main/resources/config/liquibase/changelog/20241024231608_added_entity_FeatureFlag.xml
+++ b/src/main/resources/config/liquibase/changelog/20241024231608_added_entity_FeatureFlag.xml
@@ -20,8 +20,8 @@
             <column name="description" type="varchar(255)">
                 <constraints nullable="true" />
             </column>
-            <column name="enabled" type="boolean">
-                <constraints nullable="false" default="false"/>
+            <column name="enabled" type="boolean" defaultValueBoolean="false">
+                <constraints nullable="false"/>
             </column>
             <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here -->
         </createTable>


### PR DESCRIPTION
In Liquibase `default` isn't a valid attribute on `constraints` so used `defaultValueBoolean` after looking through the [docs](https://docs.liquibase.com/change-types/nested-tags/column.html)